### PR TITLE
Updating getProduct method to POST protocol

### DIFF
--- a/src/app/home/service/home.service.ts
+++ b/src/app/home/service/home.service.ts
@@ -13,7 +13,7 @@ export class HomeService{
   ) { }
 
   async getProducts(page: number){
-    return await axios.get(`${environment.url}/products?page=${page}`)
+    return await axios.post(`${environment.url}/products?page=${page}`)
   }
 
 }


### PR DESCRIPTION
Hola Carlos, soy Samori, manager en Bokokode.

Te subo este PR para cambiar el método de getProduct a POST en lugar de GET, porque de lo contrario, no se podían usar los filtros en el body.

El fallo es nuestro porque el Postman estaba mal definido .

Un saludo.